### PR TITLE
Catch uncaught exceptions

### DIFF
--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1112,7 +1112,7 @@ class Connection {
         for (let game_id in this.connected_games) {
             this.disconnectFromGame(game_id);
         }
-        if (socket) socket.emit('notification/connect', this.auth({}), (x) => {
+        if (this.socket) this.socket.emit('notification/connect', this.auth({}), (x) => {
             conn_log(x);
         });
     }; /* }}} */

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -1108,6 +1108,9 @@ class Connection {
         for (let game_id in this.connected_games) {
             this.disconnectFromGame(game_id);
         }
+        socket.emit('notification/connect', this.auth({}), (x) => {
+            conn_log(x);
+        });
     }; /* }}} */
     on_friendRequest(notification) { /* {{{ */
         console.log("Friend request from ", notification.user.username);

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -8,7 +8,7 @@ process.on('uncaughtException', function (er) {
   if (!conn || !conn.socket) {
     conn = new Connection();
   } else {
-    conn.connection_reset();
+    //conn.connection_reset();
   }
 })
 

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -5,8 +5,11 @@
 process.on('uncaughtException', function (er) {
   console.trace("ERROR: Uncaught exception");
   console.error("ERROR: " + er.stack);
-  if (conn) conn.connection_reset();
-  if (!conn || !conn.socket) conn = new Connection();
+  if (!conn || !conn.socket) {
+    conn = new Connection();
+  } else {
+    conn.connection_reset();
+  }
 })
 
 process.title = 'gtp2ogs';

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -5,7 +5,8 @@
 process.on('uncaughtException', function (er) {
   console.trace("ERROR: Uncaught exception");
   console.error("ERROR: " + er.stack);
-  conn.connection_reset();
+  if (conn) conn.connection_reset();
+  if (!conn || !conn.socket) conn = new Connection();
 })
 
 process.title = 'gtp2ogs';
@@ -1108,7 +1109,7 @@ class Connection {
         for (let game_id in this.connected_games) {
             this.disconnectFromGame(game_id);
         }
-        socket.emit('notification/connect', this.auth({}), (x) => {
+        if (socket) socket.emit('notification/connect', this.auth({}), (x) => {
             conn_log(x);
         });
     }; /* }}} */

--- a/gtp2ogs.js
+++ b/gtp2ogs.js
@@ -2,6 +2,12 @@
 
 'use strict';
 
+process.on('uncaughtException', function (er) {
+  console.trace("ERROR: Uncaught exception");
+  console.error("ERROR: " + er.stack);
+  conn.connection_reset();
+})
+
 process.title = 'gtp2ogs';
 let DEBUG = false;
 let PERSIST = false;


### PR DESCRIPTION
Should never happen but a few errors get thrown perhaps related to bots exiting improperly which can crash gtp2ogs without this. Eventually maybe try to locate and properly handle those errors.